### PR TITLE
Make __undefined__ processing recursive

### DIFF
--- a/examples/undefined.js
+++ b/examples/undefined.js
@@ -9,3 +9,26 @@ export function returnsNull() {
 export function returnsValue() {
   return 42;
 }
+
+export function getNestedData() {
+  return {
+    prop1: undefined,
+    prop2: "defined",
+    nested: {
+      value1: undefined,
+      value2: 42,
+      deep: {
+        undefinedValue: undefined
+      }
+    }
+  };
+}
+
+export function getArrayWithUndefined() {
+  return [
+    1,
+    undefined,
+    { nested: undefined },
+    "defined"
+  ];
+}

--- a/examples/undefined.test.yaml
+++ b/examples/undefined.test.yaml
@@ -1,4 +1,4 @@
-file: './undefined.js'
+file: "./undefined.js"
 group: undefined-tests
 ---
 suite: returnsUndefined
@@ -10,9 +10,9 @@ in: []
 ---
 case: assert undefined return value with __undefined__
 in: []
-out: __undefined__  # Assert the return value is undefined
+out: __undefined__ # Assert the return value is undefined
 ---
-suite: returnsNull  
+suite: returnsNull
 exportName: returnsNull
 ---
 case: without out field - no assertion
@@ -21,7 +21,7 @@ in: []
 ---
 case: with out null - assert return is null
 in: []
-out:  # Expects null and function returns null
+out: # Expects null and function returns null
 ---
 suite: returnsValue
 exportName: returnsValue
@@ -33,3 +33,29 @@ in: []
 case: with out 42 - assert return is 42
 in: []
 out: 42
+---
+suite: getNestedData
+exportName: getNestedData
+---
+case: test nested object with __undefined__ values
+in: []
+out:
+  prop1: "__undefined__"
+  prop2: "defined"
+  nested:
+    value1: "__undefined__"
+    value2: 42
+    deep:
+      undefinedValue: "__undefined__"
+---
+suite: getArrayWithUndefined
+exportName: getArrayWithUndefined
+---
+case: test array with nested __undefined__ values
+in: []
+out:
+  - 1
+  - "__undefined__"
+  - nested: "__undefined__"
+  - "defined"
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puty",
-  "version": "0.0.5-rc1",
+  "version": "0.0.6",
   "description": "A tooling function to test javascript functions and classes.",
   "main": "src/index.js",
   "type": "module",

--- a/src/mockResolver.js
+++ b/src/mockResolver.js
@@ -5,6 +5,7 @@
  */
 
 import { vi } from "vitest";
+import { processUndefined } from "./utils.js";
 
 /**
  * Deep equality check for mock argument validation
@@ -118,20 +119,6 @@ export const createMockFunction = (mockName, mockDefinition) => {
 
     const expectedCall = calls[callIndex];
 
-    // Process __undefined__ in expected inputs recursively
-    const processUndefined = (value) => {
-      if (value === "__undefined__") return undefined;
-      if (Array.isArray(value)) return value.map(processUndefined);
-      if (value && typeof value === "object") {
-        const processed = {};
-        for (const [key, val] of Object.entries(value)) {
-          processed[key] = processUndefined(val);
-        }
-        return processed;
-      }
-      return value;
-    };
-
     const processedExpectedIn = processUndefined(expectedCall.in);
 
     // Validate input arguments
@@ -147,12 +134,7 @@ export const createMockFunction = (mockName, mockDefinition) => {
       throw new Error(expectedCall.throws);
     }
 
-    // Handle special __undefined__ keyword
-    if (expectedCall.out === "__undefined__") {
-      return undefined;
-    }
-
-    return expectedCall.out;
+    return processUndefined(expectedCall.out);
   });
 
   return {

--- a/src/puty.js
+++ b/src/puty.js
@@ -8,7 +8,7 @@ import path from "node:path";
 import yaml from "js-yaml";
 import { expect, test, describe } from "vitest";
 
-import { traverseAllFiles, parseWithIncludes } from "./utils.js";
+import { traverseAllFiles, parseWithIncludes, processUndefined } from "./utils.js";
 import {
   resolveMocks,
   processMockReferences,
@@ -254,12 +254,8 @@ const setupFunctionTests = (suite) => {
 
           // Assert return value if 'out' field is present in the test case
           if ("out" in testCase) {
-            // Handle special __undefined__ keyword
-            if (testCase.out === "__undefined__") {
-              expect(result).toBe(undefined);
-            } else {
-              expect(result).toEqual(testCase.out);
-            }
+            const expectedOut = processUndefined(testCase.out);
+            expect(result).toEqual(expectedOut);
           }
 
           // If executions are present, execute methods on the returned object
@@ -284,12 +280,8 @@ const setupFunctionTests = (suite) => {
                   execInArg || [],
                 );
                 if (execExpectedOut !== undefined) {
-                  // Handle special __undefined__ keyword
-                  if (execExpectedOut === "__undefined__") {
-                    expect(methodResult).toBe(undefined);
-                  } else {
-                    expect(methodResult).toEqual(execExpectedOut);
-                  }
+                  const processedExpectedOut = processUndefined(execExpectedOut);
+                  expect(methodResult).toEqual(processedExpectedOut);
                 }
               }
 
@@ -302,12 +294,8 @@ const setupFunctionTests = (suite) => {
                       assertion.property,
                     );
                     if (assertion.op === "eq") {
-                      // Handle special __undefined__ keyword
-                      if (assertion.value === "__undefined__") {
-                        expect(actualValue).toBe(undefined);
-                      } else {
-                        expect(actualValue).toEqual(assertion.value);
-                      }
+                      const processedValue = processUndefined(assertion.value);
+                      expect(actualValue).toEqual(processedValue);
                     }
                   } else if (assertion.method) {
                     const assertResult = callNestedMethod(
@@ -315,12 +303,8 @@ const setupFunctionTests = (suite) => {
                       assertion.method,
                       assertion.in || [],
                     );
-                    // Handle special __undefined__ keyword
-                    if (assertion.out === "__undefined__") {
-                      expect(assertResult).toBe(undefined);
-                    } else {
-                      expect(assertResult).toEqual(assertion.out);
-                    }
+                    const processedOut = processUndefined(assertion.out);
+                    expect(assertResult).toEqual(processedOut);
                   }
                 }
               }
@@ -382,12 +366,8 @@ const setupClassTests = (suite) => {
           } else {
             const result = callNestedMethod(instance, method, inArg || []);
             if (expectedOut !== undefined) {
-              // Handle special __undefined__ keyword
-              if (expectedOut === "__undefined__") {
-                expect(result).toBe(undefined);
-              } else {
-                expect(result).toEqual(expectedOut);
-              }
+              const processedExpectedOut = processUndefined(expectedOut);
+              expect(result).toEqual(processedExpectedOut);
             }
           }
 
@@ -401,12 +381,8 @@ const setupClassTests = (suite) => {
                   assertion.property,
                 );
                 if (assertion.op === "eq") {
-                  // Handle special __undefined__ keyword
-                  if (assertion.value === "__undefined__") {
-                    expect(actualValue).toBe(undefined);
-                  } else {
-                    expect(actualValue).toEqual(assertion.value);
-                  }
+                  const processedValue = processUndefined(assertion.value);
+                  expect(actualValue).toEqual(processedValue);
                 }
                 // Add more operators as needed
               } else if (assertion.method) {
@@ -416,12 +392,8 @@ const setupClassTests = (suite) => {
                   assertion.method,
                   assertion.in || [],
                 );
-                // Handle special __undefined__ keyword
-                if (assertion.out === "__undefined__") {
-                  expect(result).toBe(undefined);
-                } else {
-                  expect(result).toEqual(assertion.out);
-                }
+                const processedOut = processUndefined(assertion.out);
+                expect(result).toEqual(processedOut);
               }
             }
           }

--- a/src/utils.js
+++ b/src/utils.js
@@ -238,3 +238,25 @@ export const parseWithIncludes = (filePath) => {
 
   return processDocuments(flattenedDocs);
 };
+
+/**
+ * Recursively processes a value to convert "__undefined__" strings to actual undefined values
+ * @param {any} value - The value to process (string, array, object, or primitive)
+ * @returns {any} The processed value with "__undefined__" converted to undefined
+ * @example
+ * processUndefined("__undefined__") // returns undefined
+ * processUndefined({ a: "__undefined__", b: [1, "__undefined__"] }) 
+ * // returns { a: undefined, b: [1, undefined] }
+ */
+export const processUndefined = (value) => {
+  if (value === "__undefined__") return undefined;
+  if (Array.isArray(value)) return value.map(processUndefined);
+  if (value && typeof value === "object") {
+    const processed = {};
+    for (const [key, val] of Object.entries(value)) {
+      processed[key] = processUndefined(val);
+    }
+    return processed;
+  }
+  return value;
+};


### PR DESCRIPTION
## Problem
Previously, __undefined__ only worked for top-level values in test assertions. Nested structures like { prop: `__undefined__` } would not convert the string to actual undefined values.

## Solution
- Extract processUndefined() function to utils.js for reuse
- Apply recursive processing to all test case outputs, execution outputs, and assertions
- Remove duplicate __undefined__ processing in mockResolver.js

## Changes
- Updated test cases in examples/undefined.test.yaml to verify nested functionality
- All existing tests continue to pass (backward compatible)
- New capabilities:
  - Objects: { prop: `__undefined__`, nested: { value: `__undefined__` } }  
  - Arrays: [1, `__undefined__`, { nested: `__undefined__` }]
  - Method executions: out: { result: `__undefined__` }
  - Property assertions: value: `__undefined__`