### PR TITLE
feat: support async functions and methods in YAML tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Puty is ideal for testing pure functions - functions that always return the same
 - [Quick Start](#quick-start)
 - [Usage](#usage)
   - [Testing Functions](#testing-functions)
+  - [Async Functions and Methods](#async-functions-and-methods)
   - [Testing Classes](#testing-classes)
   - [Testing Factory Functions](#testing-factory-functions)
   - [Error Testing](#error-testing)
@@ -25,6 +26,7 @@ Puty is ideal for testing pure functions - functions that always return the same
 - 📦 Modular test organization with `!include` directive
 - 🎯 Clear separation of test data and test logic
 - 🧪 Mock support for testing functions with dependencies
+- ⏳ Async support for functions, class methods, and factory method executions
 - ⚡ Powered by Vitest for fast test execution
 
 ## Installation
@@ -199,6 +201,32 @@ describe('math', () => {
 
 See the [YAML Structure](#yaml-structure) section for detailed documentation of all available fields.
 
+### Async Functions and Methods
+
+Puty supports async functions and async method executions using the same YAML fields:
+
+- `out` asserts the resolved return value
+- `throws` asserts either a thrown error or a rejected promise
+
+Example:
+
+```yaml
+file: './async.js'
+group: async
+---
+suite: fetchUser
+exportName: fetchUser
+---
+case: resolves user
+in: [1]
+out:
+  id: 1
+---
+case: rejects for missing user
+in: [999]
+throws: 'not found'
+```
+
 ### Testing Classes
 
 Puty also supports testing classes with method calls and state assertions:
@@ -334,7 +362,9 @@ The `__undefined__` keyword works in:
 
 ### Error Testing
 
-You can test that functions or methods throw expected errors:
+You can test that functions or methods fail with expected errors:
+- Sync functions/methods: thrown errors are supported
+- Async functions/methods: rejected promises are supported
 
 ```yaml
 case: divide by zero
@@ -510,8 +540,8 @@ For function tests:
 ```yaml
 case: 'test description'   # Required: Test case name
 in: [arg1, arg2]          # Required: Input arguments (use $mock:name for mocks)
-out: expectedValue        # Optional: Expected output (omit if testing for errors)
-throws: 'Error message'   # Optional: Expected error message
+out: expectedValue        # Optional: Expected output (resolved value for async functions)
+throws: 'Error message'   # Optional: Expected error message (sync throw or async rejection)
 mocks:                    # Optional: Case-specific mocks
   mockName:
     calls:                # Array of expected calls
@@ -526,8 +556,8 @@ case: 'test description'
 executions:
   - method: 'methodName'        # Supports nested: 'user.api.getData'
     in: [arg1]
-    out: expectedValue          # Optional
-    throws: 'Error msg'         # Optional
+    out: expectedValue          # Optional (resolved value for async methods)
+    throws: 'Error msg'         # Optional (sync throw or async rejection)
     asserts:
       - property: 'prop'        # Supports nested: 'user.profile.name'
         op: 'eq'                # Currently only 'eq' is supported
@@ -563,4 +593,3 @@ executions:
         in: ['/users/123']
         out: 'GET /users/123'
 ```
-

--- a/examples/async.js
+++ b/examples/async.js
@@ -1,0 +1,63 @@
+export const asyncAdd = async (a, b) => {
+  await Promise.resolve();
+  return a + b;
+};
+
+export const asyncNoReturn = async () => {};
+
+export const asyncThrow = async () => {
+  throw new Error("boom");
+};
+
+export const syncThrow = () => {
+  throw new Error("sync boom");
+};
+
+export const runWithCallback = async (callback) => {
+  await Promise.resolve();
+  callback("done", 1);
+  return { ok: true };
+};
+
+export const createAsyncCounter = async (start = 0) => {
+  let value = start;
+
+  return {
+    getValue() {
+      return value;
+    },
+    async increment(by = 1) {
+      value += by;
+      return value;
+    },
+    failSync() {
+      throw new Error("counter failed sync");
+    },
+    async fail() {
+      throw new Error("counter failed");
+    },
+  };
+};
+
+export class AsyncCounter {
+  constructor(start = 0) {
+    this.value = start;
+  }
+
+  async increment(by = 1) {
+    this.value += by;
+    return this.value;
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  failSync() {
+    throw new Error("class failed sync");
+  }
+
+  async fail() {
+    throw new Error("class failed");
+  }
+}

--- a/examples/async.test.yaml
+++ b/examples/async.test.yaml
@@ -1,0 +1,99 @@
+file: './async.js'
+group: async-support
+---
+suite: asyncAdd
+exportName: asyncAdd
+---
+case: resolves async return value
+in:
+  - 1
+  - 2
+out: 3
+---
+suite: asyncNoReturn
+exportName: asyncNoReturn
+---
+case: supports async undefined return values
+in: []
+out: __undefined__
+---
+suite: asyncThrow
+exportName: asyncThrow
+---
+case: supports rejected promise with throws
+in: []
+throws: 'boom'
+---
+suite: syncThrow
+exportName: syncThrow
+---
+case: keeps sync throw behavior compatible
+in: []
+throws: 'sync boom'
+---
+suite: runWithCallback
+exportName: runWithCallback
+---
+case: validates mock calls from async function flow
+in:
+  - $mock:callback
+out:
+  ok: true
+mocks:
+  callback:
+    calls:
+      - in: ['done', 1]
+---
+suite: createAsyncCounter
+exportName: createAsyncCounter
+---
+case: supports async factory and async executions
+in:
+  - 5
+executions:
+  - method: getValue
+    in: []
+    out: 5
+  - method: increment
+    in:
+      - 2
+    out: 7
+  - method: getValue
+    in: []
+    out: 7
+  - method: failSync
+    in: []
+    throws: 'counter failed sync'
+  - method: fail
+    in: []
+    throws: 'counter failed'
+---
+suite: AsyncCounter
+mode: class
+exportName: AsyncCounter
+constructorArgs:
+  - 10
+---
+case: supports async class methods and assertions
+executions:
+  - method: increment
+    in:
+      - 3
+    out: 13
+    asserts:
+      - property: value
+        op: eq
+        value: 13
+      - method: getValue
+        in: []
+        out: 13
+      - method: increment
+        in:
+          - 2
+        out: 15
+  - method: failSync
+    in: []
+    throws: 'class failed sync'
+  - method: fail
+    in: []
+    throws: 'class failed'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puty",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A tooling function to test javascript functions and classes.",
   "main": "src/index.js",
   "type": "module",

--- a/src/puty.js
+++ b/src/puty.js
@@ -245,18 +245,20 @@ const setupFunctionTests = (suite) => {
       mockFunctions,
       executions,
     } = testCase;
-    test(name, () => {
+    test(name, async () => {
       if (!functionUnderTest) {
         throw new Error(`Function not found for test case: ${name}`);
       }
 
       try {
         if (throws) {
-          // Test expects an error to be thrown
-          expect(() => functionUnderTest(...(inArg || []))).toThrow(throws);
+          // Supports both sync throws and async rejections
+          await expect(
+            Promise.resolve().then(() => functionUnderTest(...(inArg || []))),
+          ).rejects.toThrow(throws);
         } else {
           // Call the function
-          const result = functionUnderTest(...(inArg || []));
+          const result = await functionUnderTest(...(inArg || []));
 
           // Assert return value if 'out' field is present in the test case
           if ("out" in testCase) {
@@ -276,11 +278,13 @@ const setupFunctionTests = (suite) => {
               } = execution;
 
               if (execThrows) {
-                expect(() =>
-                  callNestedMethod(result, method, execInArg || []),
-                ).toThrow(execThrows);
+                await expect(
+                  Promise.resolve().then(() =>
+                    callNestedMethod(result, method, execInArg || []),
+                  ),
+                ).rejects.toThrow(execThrows);
               } else {
-                const methodResult = callNestedMethod(
+                const methodResult = await callNestedMethod(
                   result,
                   method,
                   execInArg || [],
@@ -304,7 +308,7 @@ const setupFunctionTests = (suite) => {
                       expect(actualValue).toEqual(processedValue);
                     }
                   } else if (assertion.method) {
-                    const assertResult = callNestedMethod(
+                    const assertResult = await callNestedMethod(
                       result,
                       assertion.method,
                       assertion.in || [],
@@ -347,7 +351,7 @@ const setupClassTests = (suite) => {
   const { cases, ClassUnderTest, constructorArgs } = suite;
   for (const testCase of cases) {
     const { name, executions, mockFunctions } = testCase;
-    test(name, () => {
+    test(name, async () => {
       if (!ClassUnderTest) {
         throw new Error(`Class not found for test suite: ${suite.name}`);
       }
@@ -366,11 +370,13 @@ const setupClassTests = (suite) => {
 
           // Execute the method and check its return value - supports nested methods
           if (throws) {
-            expect(() =>
-              callNestedMethod(instance, method, inArg || []),
-            ).toThrow(throws);
+            await expect(
+              Promise.resolve().then(() =>
+                callNestedMethod(instance, method, inArg || []),
+              ),
+            ).rejects.toThrow(throws);
           } else {
-            const result = callNestedMethod(instance, method, inArg || []);
+            const result = await callNestedMethod(instance, method, inArg || []);
             if (expectedOut !== undefined) {
               const processedExpectedOut = processUndefined(expectedOut);
               expect(result).toEqual(processedExpectedOut);
@@ -393,7 +399,7 @@ const setupClassTests = (suite) => {
                 // Add more operators as needed
               } else if (assertion.method) {
                 // Method assertion - supports nested methods like "user.api.getData"
-                const result = callNestedMethod(
+                const result = await callNestedMethod(
                   instance,
                   assertion.method,
                   assertion.in || [],


### PR DESCRIPTION
## Summary
- add async-aware execution in the YAML runner for function tests, class executions, and assertion methods
- support `throws` for both sync throws and async rejections without changing YAML schema
- add robust async coverage examples (resolved values, undefined, sync+async throws, mocks, mixed executions)
- update README docs for async behavior and bump package version to `0.1.2`

## Backward Compatibility
- existing user YAML tests keep the same format and behavior
- sync tests remain supported; async tests now pass correctly

## Validation
- ran `bun run test`
- result: 68 passed tests across 3 files