### PR TITLE
chore(ci): support npm trusted publishers in release workflow

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -2,28 +2,22 @@ name: Publish package puty to npm
 on:
   release:
     types: [published]
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # Setup Bun
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
         with:
-          bun-version: 1.2.2
-
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      # Publish to npm
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- update npm publish workflow for npm Trusted Publishers (GitHub Actions OIDC)
- add required workflow permissions: `id-token: write`, `contents: read`
- switch to `actions/setup-node@v4` with Node `24`
- publish with `npm publish` without `NODE_AUTH_TOKEN` secret
- keep `workflow_dispatch` for manual runs

## Reference
https://docs.npmjs.com/trusted-publishers#supported-cicd-providers

## Follow-up
After merge, configure npm Trusted Publisher to point to this repository and this workflow file path.